### PR TITLE
declare emits to avoid warnings

### DIFF
--- a/src/js/components/Splide.vue
+++ b/src/js/components/Splide.vue
@@ -42,6 +42,8 @@
 			slides: Array,
 		},
 
+		emits: [...EVENTS.map(event => `splide:${event}`)],
+
     data() {
 			return {
 				splide: null,


### PR DESCRIPTION
even though with your version there is no emits warnings, I think the emits still should be declared